### PR TITLE
Remove no-longer-required ingresClassName from ingress.yaml#spec

### DIFF
--- a/basic-web-service/Chart.yaml
+++ b/basic-web-service/Chart.yaml
@@ -17,4 +17,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.1.1

--- a/basic-web-service/templates/ingress.yaml
+++ b/basic-web-service/templates/ingress.yaml
@@ -10,7 +10,6 @@ metadata:
     kubernetes.io/ingress.class: nginx
     cert-manager.io/cluster-issuer: letsencrypt
 spec:
-  ingressClassName: nginx
   tls:
   {{- range .Values.ingress.tls }}
   - hosts:


### PR DESCRIPTION
Currently `kubectl get helmrelease identity-tom -o json` shows me: 

`Invalid value: \"nginx\": can not be set when the class field is also set`

This change should fix that.