### PR TITLE
[0.1.3] Support basic servicemonitor configuration in the chart.

### DIFF
--- a/basic-web-service/Chart.yaml
+++ b/basic-web-service/Chart.yaml
@@ -17,4 +17,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.2
+version: 0.1.3

--- a/basic-web-service/templates/prometheus-service-monitor.yaml
+++ b/basic-web-service/templates/prometheus-service-monitor.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.prometheusServiceMonitor.enabled }}
+{{- $appName := include "web-service.name" . }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ $appName }}
+  namespace: default
+spec:
+  selector:
+    matchLabels:
+      namespace: default
+      app.kubernetes.io/name: {{ $appName }}
+  endpoints:
+    - port: http
+      {{- with .Values.prometheusServiceMonitor.basicAuth }}
+      basicAuth:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/basic-web-service/values.yaml
+++ b/basic-web-service/values.yaml
@@ -47,6 +47,22 @@ probes:
 
 podAnnotations: {}
 
+prometheusServiceMonitor:
+  enabled: false
+  # To enable auth (recommended!), dependent apps would need to include
+  # a map to the secret username and password, such as:
+  # basicAuth:
+  #   username:
+  #     name: <secret_name>   # e.g., 'prom-servicemanager-secrets'
+  #     key: <config_json_key>  # e.g., 'username'
+  #   password:
+  #     name: <secret_name>
+  #     key: <config_json_key>  # e.g., 'password'
+  #
+  # in this case, the `prom-servicemanager-secrets` secret would need to be
+  # json in the form of: "{username: 'promUserName', password: 'promP@55w0rd!'}"
+  basicAuth: {}
+
 environmentVariables: {}
 
 environmentSecrets: {}


### PR DESCRIPTION
- Support `ServiceMonitor` creation using: 

```yaml
prometheusServiceMonitor: 
  enabled: true
```

Also accepts a `basicAuth` block which is transposed verbatim.

---

## Validations:

### without basicAuth defined:

Using included Values:

```
app:
  name: identity-tom

prometheusServiceMonitor:
  enabled: true
```

generates: 

```
# Source: basic-web-service/templates/prometheus-service-monitor.yaml
apiVersion: monitoring.coreos.com/v1
kind: ServiceMonitor
metadata:
  name: identity-tom
  namespace: default
spec:
  selector:
    matchLabels:
      namespace: default
      app.kubernetes.io/name: identity-tom
  endpoints:
    - port: http
```

### basicAuth defined:

Using including Values:
```
app:
    name: identity-tom

prometheusServiceMonitor:
  enabled: true
  basicAuth:
    username:
      key: user
      name: prom-servicemanager-runtime-configuration
    password:
      key: password
      name: prom-servicemanager-runtime-configuration
```

Generates:
```
# Source: basic-web-service/templates/prometheus-service-monitor.yaml
apiVersion: monitoring.coreos.com/v1
kind: ServiceMonitor
metadata:
  name: identity-tom
  namespace: default
spec:
  selector:
    matchLabels:
      namespace: default
      app.kubernetes.io/name: identity-tom
  endpoints:
    - port: http
      basicAuth:
        password:
          key: password
          name: prom-servicemanager-runtime-configuration
        username:
          key: user
          name: prom-servicemanager-runtime-configuration
```