### PR TITLE
Don't set default host/tls values.

### DIFF
--- a/basic-web-service/Chart.yaml
+++ b/basic-web-service/Chart.yaml
@@ -17,4 +17,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.5
+version: 0.1.6

--- a/basic-web-service/templates/deployment.yaml
+++ b/basic-web-service/templates/deployment.yaml
@@ -41,6 +41,7 @@ spec:
             - name: http
               containerPort: {{ .Values.ports.containerHttpPort }}
               protocol: TCP
+          {{- if .Values.probes.liveness.enabled }}
           livenessProbe:
             httpGet:
               path: {{ .Values.probes.liveness.path }}
@@ -50,6 +51,7 @@ spec:
             periodSeconds: {{ .Values.probes.liveness.periodSeconds }}
             successThreshold: {{ .Values.probes.liveness.successThreshold }}
             timeoutSeconds: {{ .Values.probes.liveness.timeoutSeconds }}
+          {{- end}}
           readinessProbe:
             httpGet:
               path: {{ .Values.probes.readiness.path }}

--- a/basic-web-service/values.yaml
+++ b/basic-web-service/values.yaml
@@ -83,14 +83,14 @@ service:
 ingress:
   enabled: false
   annotations: {}
-  hosts:
-    - host: chart-example.local
-      paths:
-        - path: /
-  tls:
-    - secretName: chart-example-tls
-      hosts:
-        - chart-example.local
+  hosts: []
+    #- host: chart-example.local
+    #  paths:
+    #    - path: /
+  tls: []
+    #- secretName: chart-example-tls
+    #  hosts:
+    #    - chart-example.local
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious


### PR DESCRIPTION
This led to `chart.example.local` being set as a default TLS value if none was present, even if it wasn't desired by the service.