### PR TITLE
Add Github Action to publish new charts

### DIFF
--- a/.github/workflows/helm-lint.yml
+++ b/.github/workflows/helm-lint.yml
@@ -7,6 +7,11 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: ./.github/actions/set-up-helm-linter
       - run: helm lint basic-web-service
+      - uses: actions/setup-go@v4
+        with:
+          go-version: '1.17'
+      - run: go install github.com/yannh/kubeconform/cmd/kubeconform@latest
+      - run: helm template basic-web-service | kubeconform --summary --output json

--- a/.github/workflows/publishChart.yml
+++ b/.github/workflows/publishChart.yml
@@ -1,0 +1,24 @@
+name: Publish new chart 
+on:
+  push:
+    branches:
+      - 'main'
+    paths:
+      - 'basic-web-service/Chart.yaml'
+jobs:
+  PublishChart:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo 'Chart.yaml has changed, updating gh-pages branch'
+      - name: Checkout 🛎
+        uses: actions/checkout@v3
+        with:
+          # check out all branches
+          fetch-depth: 0
+      - name: Publish to Github Pages
+        run: |
+          git config user.name "${GITHUB_ACTOR}"
+          git config user.email "${GITHUB_ACTOR_ID}+${GITHUB_ACTOR}@users.noreply.github.com" 
+          git checkout gh-pages
+          git rebase origin/main
+          git push origin gh-pages

--- a/.github/workflows/publishChart.yml
+++ b/.github/workflows/publishChart.yml
@@ -15,6 +15,11 @@ jobs:
         with:
           # check out all branches
           fetch-depth: 0
+      - name: Get latest chart version number
+        run: echo "CHART_VERSION=$(cat basic-web-service/Chart.yaml | grep 'version:' | cut -d' ' -f2)" >> $GITHUB_ENV 
+      - name: Check for matching archive
+        run: |
+          echo "If this step fails, we couldn't find the file 'charts/basic-web-service-${CHART_VERSION}.tgz'" && [[ -e  "charts/basic-web-service-${CHART_VERSION}.tgz" ]]
       - name: Publish to Github Pages
         run: |
           git config user.name "${GITHUB_ACTOR}"


### PR DESCRIPTION
Action is configured to run any time an updated `Chart.yaml` is pushed `main`.

Essentially identical to the manual step listed in the README. There is a tool released by the Helm team, `chart-releaser`, that handles this in a similar way that is probably worth looking into more closely at some point. I played around with it but it wasn't clear to me that it added much value given how we currently publish new charts. I also couldn't get it to play nice.

TODO

- [x] Check to make sure you've run `package-chart.sh` (look for .tgz file with same version)
- [x] Run `helm lint` in the same action?